### PR TITLE
Allow Add Folder button to work without jQuery UI

### DIFF
--- a/assets/js/emfm-admin.js
+++ b/assets/js/emfm-admin.js
@@ -454,17 +454,19 @@ jQuery(document).ready(function($) {
 
     // Initialize plugin
     function init() {
-        if (!$.ui || !$.ui.draggable || !$.ui.droppable || !$.ui.sortable) {
-            console.error('jQuery UI dependencies missing');
-            return;
-        }
-        waitForElements();
         handleFolderCreation();
         handleFolderNavigation();
         handleFolderSorting();
         handleFolderMenuActions();
         handleMediaListDropdown();
         handleOutsideClick();
+
+        if ($.ui && $.ui.draggable && $.ui.droppable && $.ui.sortable) {
+            waitForElements();
+        } else {
+            console.warn('jQuery UI dependencies missing; drag-and-drop disabled');
+        }
+
         setTimeout(applySavedSort, 500); // Fallback sort
     }
 


### PR DESCRIPTION
## Summary
- Initialize folder creation and navigation regardless of jQuery UI availability
- Guard drag-and-drop setup with dependency check to prevent early exit

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a81a69fa548326bd580e20195c9a2d