### PR TITLE
Fix fatal error from private get_term_depth usage

### DIFF
--- a/includes/classes/class-easy-media-folder-manager.php
+++ b/includes/classes/class-easy-media-folder-manager.php
@@ -397,10 +397,16 @@ class Easy_Media_Folder_Manager {
     /**
      * Get term depth for indentation.
      *
+     * This method is used by other classes, such as the custom media list
+     * table, to correctly indent folder names based on their hierarchy.  The
+     * previous implementation declared this method as `private`, which caused a
+     * fatal error when external classes attempted to call it.  Changing the
+     * visibility to `public` allows those classes to reuse the logic safely.
+     *
      * @param WP_Term $term Term object.
      * @return int Depth level.
      */
-    private function get_term_depth($term) {
+    public function get_term_depth($term) {
         $depth = 0;
         while ($term->parent) {
             $depth++;

--- a/media-folders.php
+++ b/media-folders.php
@@ -3,7 +3,7 @@
  * Plugin Name: Easy Media Folder Manager
  * Plugin URI: https://github.com/ScottReinmuth/easy-media-folder-manager
  * Description: Organize your WordPress media library into folders for easier management.
- * Version: 1.2.1
+ * Version: 1.2.2
  * Author: Scott Reinmuth
  * Author URI: https://github.com/ScottReinmuth
  * License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: scottreinmuth
 Tags: media, folders, organization, file manager
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -56,6 +56,9 @@ Clear the `emfm_folders` transient in the WordPress database (using a plugin lik
 
 == Changelog ==
 
+= 1.2.2 =
+- Exposed folder depth helper to prevent fatal error when used outside the class.
+
 = 1.2.1 =
 - Fixed folder action buttons using translation-independent identifiers.
 - Added nonce existence checks and safe redirects for folder actions.
@@ -84,6 +87,9 @@ Clear the `emfm_folders` transient in the WordPress database (using a plugin lik
 - Initial release.
 
 == Upgrade Notice ==
+
+= 1.2.2 =
+Fixes fatal error when retrieving folder hierarchy depth outside core.
 
 = 1.2.1 =
 Ensures folder actions work across translated WordPress installations and improves security checks.


### PR DESCRIPTION
## Summary
- expose `Easy_Media_Folder_Manager::get_term_depth()` as public so other components can reuse it
- document method purpose and why visibility change is necessary
- bump plugin version to 1.2.2 and update changelog

## Testing
- `find . -name "*.php" -exec php -l {} \;` *(fails: php not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68a82327b2508326a234ade4a26d96ff