### PR TITLE
Fix folder content not displaying

### DIFF
--- a/assets/js/emfm-admin.js
+++ b/assets/js/emfm-admin.js
@@ -278,8 +278,7 @@ jQuery(document).ready(function($) {
             }
 
             const folderId = $(this).data('folder-id');
-            const folder = folderId === 0 ? null : emfm_data.folders.find(f => f.term_id == folderId);
-            const newUrl = 'upload.php' + (folder ? '?media_folder=' + folder.slug : '');
+            const newUrl = 'upload.php' + (folderId ? '?media_folder=' + folderId : '');
 
             $('#emf-folder-list .emf-folder-item').removeClass('emf-folder-active');
             $(this).addClass('emf-folder-active');

--- a/includes/classes/class-easy-media-folder-manager.php
+++ b/includes/classes/class-easy-media-folder-manager.php
@@ -71,15 +71,21 @@ class Easy_Media_Folder_Manager {
      */
     public function filter_media_by_folder($query) {
         global $pagenow;
-        if (is_admin() && $pagenow === 'upload.php' && !empty($_GET['media_folder'])) {
-            $query->set('tax_query', [
-                [
-                    'taxonomy' => 'emfm_media_folder',
-                    'field' => 'slug',
-                    'terms' => sanitize_text_field($_GET['media_folder']),
-                ],
-            ]);
+        if (!is_admin() || $pagenow !== 'upload.php' || empty($_GET['media_folder']) || !$query->is_main_query()) {
+            return;
         }
+
+        $folder     = sanitize_text_field($_GET['media_folder']);
+        $field_type = is_numeric($folder) ? 'term_id' : 'slug';
+        $folder     = ('term_id' === $field_type) ? absint($folder) : $folder;
+
+        $query->set('tax_query', [
+            [
+                'taxonomy' => 'emfm_media_folder',
+                'field'    => $field_type,
+                'terms'    => $folder,
+            ],
+        ]);
     }
 
     /**


### PR DESCRIPTION
## Summary
- ensure media filter supports both folder IDs and slugs and runs only on main query
- update folder navigation to request folder by ID instead of slug

## Testing
- `php -l includes/classes/class-easy-media-folder-manager.php`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a83248b3d0832699771b9bb73a4298