### PR TITLE
Fix folder sorting via AJAX and refresh manual drag order

### DIFF
--- a/assets/js/emfm-admin.js
+++ b/assets/js/emfm-admin.js
@@ -176,7 +176,33 @@ jQuery(document).ready(function($) {
             }).done(response => {
                 if (response.success) {
                     $folderList.html(response.data.html);
+                    // Reattach droppable to new folder elements.
+                    const $newFolders = $folderList.find('.emf-folder-item:not(.ui-droppable)');
+                    $newFolders.droppable({
+                        accept: '.attachment, tr, .media-item',
+                        hoverClass: 'emf-folder-hover',
+                        drop: function(event, ui) {
+                            const mediaId = ui.draggable.data('id') || ui.draggable.find('input[type="checkbox"]').val();
+                            if (!mediaId) return;
+
+                            const folderId = $(this).data('folder-id');
+                            $.post(emfm_data.ajax_url, {
+                                action: 'emfm_assign_folder',
+                                media_id: mediaId,
+                                folder_id: folderId,
+                                nonce: emfm_data.nonce
+                            }).done(res => {
+                                if (res.success) {
+                                    window.location.reload();
+                                } else {
+                                    alert('Error: ' + (res.data || 'Unknown error'));
+                                }
+                            }).fail(handleAjaxError);
+                        }
+                    });
+
                     if ($folderList.hasClass('ui-sortable')) {
+                        $folderList.sortable('refresh');
                         if (savedSort === 'manual') {
                             $folderList.sortable('enable');
                         } else {

--- a/includes/ajax-handlers.php
+++ b/includes/ajax-handlers.php
@@ -189,6 +189,13 @@ function emfm_save_folder_order_callback() {
         }
     }
 
+    // Clear cached folder data so sorting updates immediately.
+    delete_transient('emfm_folders');
+    $sort_keys = ['name-asc', 'name-desc', 'date-asc', 'date-desc', 'count-asc', 'count-desc', 'manual'];
+    foreach ($sort_keys as $key) {
+        delete_transient('emfm_sorted_folders_' . md5($key));
+    }
+
     wp_send_json_success(['message' => __('Folder order saved successfully', 'easy-media-folder-manager')]);
 }
 add_action('wp_ajax_emfm_save_folder_order', 'emfm_save_folder_order_callback');

--- a/includes/classes/class-easy-media-folder-manager.php
+++ b/includes/classes/class-easy-media-folder-manager.php
@@ -323,9 +323,9 @@ class Easy_Media_Folder_Manager {
                     case 'count-desc':
                         return ($b->count ?? 0) - ($a->count ?? 0);
                     case 'manual':
-                        $a_order = get_term_meta($a->term_id, 'emf_folder_order', true) ?: PHP_INT_MAX;
-                        $b_order = get_term_meta($b->term_id, 'emf_folder_order', true) ?: PHP_INT_MAX;
-                        return $a_order - $b_order;
+                        $a_order = isset($a->meta['emf_folder_order']) ? (int) $a->meta['emf_folder_order'] : PHP_INT_MAX;
+                        $b_order = isset($b->meta['emf_folder_order']) ? (int) $b->meta['emf_folder_order'] : PHP_INT_MAX;
+                        return $a_order <=> $b_order;
                     default:
                         return 0;
                 }


### PR DESCRIPTION
## Summary
- clear folder cache when saving order
- reinitialize droppable elements and sortable refresh after AJAX sorting
- use stored metadata for manual sorting so folders with order 0 remain first

## Testing
- `php -l includes/classes/class-easy-media-folder-manager.php`
- `php -l includes/ajax-handlers.php`
- `node --check assets/js/emfm-admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68a832e18ff88326a85333171a69b8a1